### PR TITLE
tiny bugfix: brainmask excludes UNI values =0 

### DIFF
--- a/func/T1B1correctpackage.m
+++ b/func/T1B1correctpackage.m
@@ -164,7 +164,8 @@ end
 T1temp = MP2RAGEimg;
 B1temp = Sa2RAGEimg;
 brain.img(Sa2RAGEimg.img==0)          = 0;
-brain.img(MP2RAGEimg.img==0)          = 0;
+brain.img(MP2RAGEimg.img==...
+    min(MP2RAGEimg.img(:)))           = 0;
 T1temp.img(brain.img==0)              = 0;
 T1temp.img(brain.img==1)              = 1.5;
 B1temp.img(brain.img==0)              = 0;

--- a/func/T1B1correctpackageTFL.m
+++ b/func/T1B1correctpackageTFL.m
@@ -156,7 +156,8 @@ end
 T1temp                        = MP2RAGEimg;
 
 brain.img(B1img.img==0)       = 0;
-brain.img(MP2RAGEimg.img==0)  = 0;
+brain.img(MP2RAGEimg.img==...
+    min(MP2RAGEimg.img(:)))   = 0;
 T1temp.img(brain.img==0)      = 0;
 T1temp.img(brain.img==1)      = 0;
 B1img.img(brain.img==0)       = 0;


### PR DESCRIPTION
A problem occurs, when no brainmask is provided to voxels of the UNI image with intensity == 0.
As the range of the MP2RAGE image has been already scaled to -0.5 to 0.5, the intensity 0 does not represent the background (as probably intended?). Therefore I suggest to select the minimum values of the current MP2RAGE image instead